### PR TITLE
AWS Lambda Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ Once package installation is complete, activate the new conda environment and st
 
 The Streamlit app is now running locally on port 8501
 
+## Local Docker Setup
+
+To build a Docker container running the application locally, run the following:
+
+Clone the repository
+
+    git clone https://github.com/kheyer/Deep-Synthesis
+    
+Build the container
+
+    docker build -f build/local.Dockerfile -t deep_synthesis .
+    docker run -p 8501:8501 deep_synthesis
+
+The Streamlit app is now running locally on port 8501
+
+
 ## Local Inference
 
 Once the Streamlit app is running locally, inference can be run on local hardware. There are two ways to run inference. The "Predict from String" option predicts on a single SMILES string entered into the text entry box.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Follow the package installation prompts.
 Once package installation is complete, activate the new conda environment and start the Streamlit app
 
     source activate deep_synthesis
-    streamlit run Synthesis/app.py
+    streamlit run Synthesis/app.py local
 
 The Streamlit app is now running locally on port 8501
 

--- a/Synthesis/app.py
+++ b/Synthesis/app.py
@@ -38,6 +38,7 @@ elif runtime == 'AWS':
     # Asyncronously ping fan_size instances concurrently
     # to prevent cold start
     warmup_lambda(model_description['fan_size'], model_description['function'])
+    
 else:
     raise ValueError('''Please provide a valid runtime argument. Use 'local' to run predictions locally, or 
                 'AWS' to run predictions on AWS (AWS inference requires permissions)''')
@@ -51,19 +52,24 @@ prediction_option = st.selectbox('Select an Input Format', input_options)
 
 single_predict, source_param, target_param = get_data_params(input_options, prediction_option)
 
-if st.checkbox('Load Data'):
-    smile_data = load_data(single_predict, source_param, target_param)
+data_box = st.checkbox('Load Data')
 
-    display_data(smile_data)
+if data_box:
+    smile_data = load_data(single_predict, source_param, target_param)
+    display_idx = display_slider(smile_data)
+
+    display_data(smile_data, display_idx)
 
     st.write('Input Prediction Parameters')
     beam = int(st.selectbox('Select Beam Width', [1,2,3,5]))
     n_best = int(st.selectbox('Select Top K Predictions', [1,2,3,5]))
 
-    if st.checkbox('Run Prediction'):
+    prediction_box = st.checkbox('Run Prediction')
+
+    if prediction_box:
         placeholder = st.empty()
         placeholder.text('Translation in Progress')
         prediction = translate_data(smile_data, beam, n_best, True, translator_class, model_description)
         placeholder.text('Translation Complete')
 
-        display_prediction(prediction)
+        display_prediction(prediction, display_idx)

--- a/Synthesis/app.py
+++ b/Synthesis/app.py
@@ -19,8 +19,8 @@ if st.checkbox('Load Data'):
     display_data(smile_data)
 
     st.write('Input Prediction Parameters')
-    beam = int(st.text_input('Beam Width', '10'))
-    n_best = int(st.text_input('Top K Predictions', '5'))
+    beam = int(st.selectbox('Select Beam Width', [1,2,3,5]))
+    n_best = int(st.selectbox('Select Top K Predictions', [1,2,3,5]))
 
     if st.checkbox('Run Prediction'):
         placeholder = st.empty()

--- a/Synthesis/app.py
+++ b/Synthesis/app.py
@@ -4,6 +4,7 @@ import json
 from utils import *
 from preprocess import *
 from translate_aws import *
+from lambda_async import *
 
 # Importing translate also imports OpenNMT.
 # Putting this in a try/except block allows for deploying
@@ -33,6 +34,10 @@ if runtime == 'local':
     translator_class = TranslationModel
 elif runtime == 'AWS':
     translator_class = LambdaInterface
+
+    # Asyncronously ping fan_size instances concurrently
+    # to prevent cold start
+    warmup_lambda(model_description['fan_size'])
 else:
     raise ValueError('''Please provide a valid runtime argument. Use 'local' to run predictions locally, or 
                 'AWS' to run predictions on AWS (AWS inference requires permissions)''')

--- a/Synthesis/app.py
+++ b/Synthesis/app.py
@@ -37,7 +37,7 @@ elif runtime == 'AWS':
 
     # Asyncronously ping fan_size instances concurrently
     # to prevent cold start
-    warmup_lambda(model_description['fan_size'])
+    warmup_lambda(model_description['fan_size'], model_description['function'])
 else:
     raise ValueError('''Please provide a valid runtime argument. Use 'local' to run predictions locally, or 
                 'AWS' to run predictions on AWS (AWS inference requires permissions)''')

--- a/Synthesis/app.py
+++ b/Synthesis/app.py
@@ -1,23 +1,42 @@
 import streamlit as st 
 import argparse
+import json
+from utils import *
+from preprocess import *
+from translate_aws import *
 
+# Importing translate also imports OpenNMT.
+# Putting this in a try/except block allows for deploying
+# the app configured to run AWS Lambda predictions
+# without bringing along OpenNMT
+try:
+    from translate import *
+except ModuleNotFoundError:
+    pass
+
+# define runtime specifications on launch
 parser = argparse.ArgumentParser()
 parser.add_argument("runtime", help="Argument to select local or AWS runtimes ['local' or 'AWS']")
 args = parser.parse_args()
 
-import json
-from utils import *
-from preprocess import *
+# Dictionary of configuration files
+config_json_opts = {
+                      'AWS' : 'configs/aws_description.json',
+                      'local' : 'configs/model_description.json'
+                   }
 
-if args.runtime == 'local':
-    from translate import *
-    model_description = json.load(open('configs/model_description.json'))
-elif args.runtime == 'AWS':
-    from translate_aws import *
-    model_description = json.load(open('configs/aws_description.json'))
+runtime = args.runtime 
+model_description = json.load(open(config_json_opts[runtime]))
+
+# Define class to handle translations based on runtime
+if runtime == 'local':
+    translator_class = TranslationModel
+elif runtime == 'AWS':
+    translator_class = LambdaInterface
 else:
     raise ValueError('''Please provide a valid runtime argument. Use 'local' to run predictions locally, or 
                 'AWS' to run predictions on AWS (AWS inference requires permissions)''')
+
 
 st.title('Deep Synthesis')
 
@@ -39,7 +58,7 @@ if st.checkbox('Load Data'):
     if st.checkbox('Run Prediction'):
         placeholder = st.empty()
         placeholder.text('Translation in Progress')
-        prediction = translate_data(smile_data, beam, n_best, True, model_description)
+        prediction = translate_data(smile_data, beam, n_best, True, translator_class, model_description)
         placeholder.text('Translation Complete')
 
         display_prediction(prediction)

--- a/Synthesis/app.py
+++ b/Synthesis/app.py
@@ -1,13 +1,27 @@
 import streamlit as st 
-import json
+import argparse
 
+parser = argparse.ArgumentParser()
+parser.add_argument("runtime", help="Argument to select local or AWS runtimes ['local' or 'AWS']")
+args = parser.parse_args()
+
+import json
 from utils import *
 from preprocess import *
+
+if args.runtime == 'local':
+    from translate import *
+    model_description = json.load(open('configs/model_description.json'))
+elif args.runtime == 'AWS':
+    from translate_aws import *
+    model_description = json.load(open('configs/aws_description.json'))
+else:
+    raise ValueError('''Please provide a valid runtime argument. Use 'local' to run predictions locally, or 
+                'AWS' to run predictions on AWS (AWS inference requires permissions)''')
 
 st.title('Deep Synthesis')
 
 input_options = app_setup()
-model_description = json.load(open('configs/model_description.json'))
 
 prediction_option = st.selectbox('Select an Input Format', input_options)
 
@@ -25,7 +39,7 @@ if st.checkbox('Load Data'):
     if st.checkbox('Run Prediction'):
         placeholder = st.empty()
         placeholder.text('Translation in Progress')
-        prediction = translate_data(smile_data, beam, n_best, model_description)
+        prediction = translate_data(smile_data, beam, n_best, True, model_description)
         placeholder.text('Translation Complete')
 
         display_prediction(prediction)

--- a/Synthesis/lambda_async.py
+++ b/Synthesis/lambda_async.py
@@ -1,0 +1,90 @@
+'''
+Non-blocking concurrent requests to AWS Lambda API endpoints
+with Python asyncio and aiohttp
+
+Code adapted from gist by Mathew Marcus
+https://gist.github.com/byrro/439d233636ac6894f87c1df6ff1fa298
+
+    Credits to Mathew Marcus (2019)
+    https://www.mathewmarcus.com/blog/
+    http://archive.is/nXkCb
+'''
+
+import asyncio
+import json
+import os
+from typing import Dict, List
+import urllib
+
+import aiohttp
+from botocore import session, awsrequest, auth
+
+AWS_CREDENTIALS = session.Session().get_credentials()
+
+def sign_headers(*, url: str, payload: Dict):
+    '''Sign AWS API request headers'''
+    segments = urllib.parse.urlparse(url).netloc.split('.')
+    service = segments[0]
+    region = segments[1]
+
+    request = awsrequest.AWSRequest(
+        method='POST',
+        url=url,
+        data=json.dumps(payload),
+    )
+
+    auth.SigV4Auth(AWS_CREDENTIALS, service, region).add_auth(request)
+
+    return dict(request.headers.items())
+
+
+async def invoke(*, url: str, payload: Dict, session):
+    '''Invoke a Lambda function'''
+    signed_headers = sign_headers(url=url, payload=payload)
+
+    async with session.post(url, json=payload, headers=signed_headers) \
+            as response:
+        return await response.json()
+
+
+def run_invocations(
+        *,
+        requests: List,
+        base_url: str,
+        session,
+        is_async: bool,
+        ):
+    for request in requests:
+        method = 'invoke-async' if is_async is True else 'invocations'
+
+        url = os.path.join(base_url, request['function_name'], method)
+
+        yield invoke(url=url, payload=request['payload'], session=session)
+
+
+def invoke_all(
+        *,
+        requests: List,
+        region: str = 'us-east-1',
+        is_async: bool = False,
+        ):
+    
+    base_url = f'https://lambda.{region}.amazonaws.com/2015-03-31/functions'
+
+    async def wrapper():
+        async with aiohttp.ClientSession(raise_for_status=True) as session:
+            invocations = run_invocations(
+                requests=requests,
+                base_url=base_url,
+                session=session,
+                is_async=is_async,
+            )
+
+            return await asyncio.gather(*invocations)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    results = loop.run_until_complete(wrapper())
+
+    return results

--- a/Synthesis/lambda_async.py
+++ b/Synthesis/lambda_async.py
@@ -106,16 +106,16 @@ def background(f):
 
 
 @background
-def warmup(payload):
+def warmup(payload, function):
     client = boto3.client('lambda')
     print('sending request')
-    client.invoke(FunctionName='TranslationFunction',
+    client.invoke(FunctionName=function,
                              InvocationType='RequestResponse',
                              Payload=json.dumps(payload))
     print("warmup completed")
 
 @st.cache
-def warmup_lambda(fan_size):
+def warmup_lambda(fan_size, function):
     payload = { 'data': '""',
                 'beam': '',
                 'n_best': '',
@@ -123,6 +123,6 @@ def warmup_lambda(fan_size):
                 'warmup': True}
     for i in range(fan_size):
         print('starting warmup')
-        warmup(payload)
+        warmup(payload, function)
         time.sleep(0.1)
     return 'warmup complete'

--- a/Synthesis/postprocess.py
+++ b/Synthesis/postprocess.py
@@ -58,7 +58,7 @@ class Predictions():
             
         for i in range(len(self.scores)):
             preds_flat += self.preds[i]
-            scores_flat += [score.item() for score in self.scores[i]]
+            scores_flat += [score for score in self.scores[i]]
             sources_flat += [self.sources[i] for j in range(len(self.scores[i]))]
             prediction_ids += [i for j in range(len(self.scores[i]))]
         
@@ -120,10 +120,10 @@ def display_parameters(prediction, idx=0):
     
     if prediction.do_target:
         correct = list(prediction.df[prediction.df.ID == idx].Correct.values)
-        legend = [f'Prediction {i}, Probability {np.exp(score.item()):.4} ({corr})' 
+        legend = [f'Prediction {i}, Probability {np.exp(score):.4} ({corr})' 
                   for i, (score, corr) in enumerate(zip(scores, correct))]
     else:
-        legend = [f'Prediction {i}, Probability {np.exp(score.item()):.4}' 
+        legend = [f'Prediction {i}, Probability {np.exp(score):.4}' 
                   for i, score in enumerate(scores)]
         
     params = list(zip(source_tokens, prediction_tokens, attentions, legend))

--- a/Synthesis/postprocess.py
+++ b/Synthesis/postprocess.py
@@ -156,16 +156,19 @@ def plot_attention(source, target, attention):
     # Attention score is padded based on batch prediction
     # We truncate to the relevant size based on source and target tokens
     attention = attention[:len(target_toks), :len(source_toks)]
-    figsize = (attention.shape[1]//2, attention.shape[0]//2)
+    figsize = (attention.shape[1]//3, attention.shape[0]//3)
     fig, ax1 = plt.subplots(figsize=figsize)
 
-    ax = sns.heatmap(attention, linewidths=0.01, ax=ax1, linecolor='black',
+    ax = sns.heatmap(attention, linewidths=0.1, ax=ax1, linecolor='black',
                     xticklabels=source_toks, yticklabels=target_toks, square=True,
                     cmap=sns.color_palette("YlGn", n_colors=15), 
                     cbar_kws={"shrink": 0.5, 'pad':0.04, 'label': 'Attention Score'})
 
     ax.set_xlabel('Source Tokens')
     ax.set_ylabel('Target Tokens')
+
+    loc, labels = plt.yticks()
+    ax.set_yticklabels(labels, rotation=360)
 
     ax.tick_params(top=True, bottom=False,
                 labeltop=False, labelbottom=True)

--- a/Synthesis/translate.py
+++ b/Synthesis/translate.py
@@ -1,3 +1,4 @@
+import streamlit as st
 import sys 
 sys.path.insert(0, 'OpenNMT-py')
 
@@ -8,6 +9,7 @@ import torch
 
 import types
 import io
+from postprocess import *
 
 class TranslationModel:
     '''
@@ -136,3 +138,21 @@ class TranslationModel:
             bs = 64
             
         return bs
+
+@st.cache(ignore_hash=True)
+def translate_data(smile_data, beam, n_best, attention, model_description):
+    Translation = TranslationModel(model_description)
+    scores, preds, attns = Translation.run_translation(smile_data.smiles_tokens, 
+                                                beam=beam, n_best=n_best, return_attention=attention)
+    scores = process_scores(scores)
+    prediction = Predictions(smile_data, preds, scores, attns)
+    return prediction
+
+def process_scores(scores):
+    new_scores = []
+
+    for score_set in scores:
+        float_scores = [i.item() for i in score_set]
+        new_scores += [float_scores]
+    
+    return new_scores

--- a/Synthesis/translate.py
+++ b/Synthesis/translate.py
@@ -94,6 +94,8 @@ class TranslationModel:
         # outputs from translation
         # all outputs are lists of lists
         scores, preds, attns = self.translator.translate(src, batch_size=bs, return_attention=True)
+
+        scores = process_scores(scores)
         
         if beam or n_best:
             self.reset_params()
@@ -119,7 +121,7 @@ class TranslationModel:
 
     def get_batch_size_cpu(self, beam):
         # Optinum batch sizes for CPU inference
-        # based on AWS Lambda 2048 MB instance
+        # based on AWS Lambda 3008 MB instance
         if beam >= 10:
             return 10
         else:
@@ -138,15 +140,6 @@ class TranslationModel:
             bs = 64
             
         return bs
-
-@st.cache(ignore_hash=True)
-def translate_data(smile_data, beam, n_best, attention, model_description):
-    Translation = TranslationModel(model_description)
-    scores, preds, attns = Translation.run_translation(smile_data.smiles_tokens, 
-                                                beam=beam, n_best=n_best, return_attention=attention)
-    scores = process_scores(scores)
-    prediction = Predictions(smile_data, preds, scores, attns)
-    return prediction
 
 def process_scores(scores):
     new_scores = []

--- a/Synthesis/translate_aws.py
+++ b/Synthesis/translate_aws.py
@@ -1,0 +1,161 @@
+import streamlit as st 
+import math
+import boto3
+import json
+import pickle
+import gzip
+import numpy as np
+
+from lambda_async import *
+from postprocess import *
+
+
+class LambdaInterface():
+    '''
+    Class to prepare data and interface with AWS Lambda function
+
+    Data is batched in two steps.
+    First the data is batched into chunks of size "payload",
+    where payload is the number of samples sent to a lambda
+    function during a single invocation.
+
+    Payload sizes are hard coded based on experimenting with
+    the performance of an AWS Lambda 2048 MB function
+
+    Second, payload chunks are batched into invocation chunks
+    of size "fan_size", where "fan_size" is the number of 
+    concurrent lambda invocations. 
+    
+    Currently, "fan_size" is set to be no more than 4
+
+    Once data is batched, running the "predict_async" function
+    will use the functions in the lambda_async.py file to 
+    invoke all invocation_chunks simultaneously
+    '''
+    def __init__(self, data, beam, n_best, attention, function, bucket):
+        self.data = data
+        self.beam = beam
+        self.n_best = n_best
+        self.attention = attention
+        self.function = function
+        self.bucket = bucket
+        self.s3 = boto3.client('s3')
+                
+        self.chunksize_dict = {
+                                1 : 60,
+                                2 : 50,
+                                3 : 40,
+                                5 : 30
+                              }
+
+        self.payload_size = self.chunksize_dict[beam]
+
+        # concurrent invocations will be up to 4
+        self.fan_size = min(4, math.ceil(len(data)/self.payload_size))
+        
+        self.region = 'us-west-2'
+        
+    def chunk_data(self, data, chunksize):
+        # partitions a list into chunks of size chunksize
+        return [data[i:i+chunksize] for i in range(0, len(data), chunksize)]
+    
+    def data_to_payload(self, data):
+        # writes a list of data payloads into a json format compatible
+        # with the functions in lambda_async.py
+        requests = []
+
+        for data_item in data:
+
+            data_dict = {
+                            "function_name" : self.function,
+                            "payload" : {"data" : json.dumps(data_item),
+                                         "beam" : self.beam,
+                                         "n_best" : self.n_best,
+                                         "return_attention" : self.attention}
+                        }
+
+            requests.append(data_dict)
+
+        return requests
+    
+    def process_response(self, response):
+        # Due to the size of the response (mostly the attention maps)
+        # responses are not returned directly. They are stored in a s3 bucket
+        # as gzipped pickle files, and the item key is returned in the response
+        s3_key = response['body']['s3_key']
+        outputs = self.s3.get_object(Bucket=self.bucket, Key=s3_key)
+        output_dict = pickle.loads(gzip.decompress(outputs['Body'].read()))
+        
+        predictions = output_dict['predictions']
+        scores = output_dict['scores']
+        attention = output_dict['attention']
+
+        # delete item from bucket after it is retrieved 
+        self.s3.delete_object(Bucket=self.bucket, Key=s3_key)
+        
+        return predictions, scores, attention
+    
+    def reconstruct_output(self, output):
+        # Raw invocation outputs are a list of json responses 
+        # containing s3 item keys pointing to the actual prediction outputs
+
+        # This function retrieves those outputs and combines them into 
+        # a single set of lists
+        output = [self.process_response(i) for i in output]
+    
+        preds = []
+        scores = []
+        attns = []
+        for out in output:
+            preds_iter, scores_iter, attns_iter = out
+            preds += preds_iter
+            scores += scores_iter
+            attns += attns_iter
+
+        return preds, scores, attns
+
+    def reconstruct_attention(self, attns):
+        # Attention maps are loaded as lists of lists.
+        # This function reconstructs them into numpy arrays
+        reconstructed_attentions = []
+
+        for attention_set in attns:
+            array_attentions = [np.array(i) for i in attention_set]
+            reconstructed_attentions += [array_attentions]
+
+        return reconstructed_attentions
+    
+    def predict_async(self):
+        # runs async prediction
+
+        # break data into chunks of size payload_size
+        chunked_data = self.chunk_data(self.data, self.payload_size)
+
+        # process payload chunks into json format
+        payload_chunks = self.data_to_payload(chunked_data)
+
+        # break payloads into invocation chunks
+        # each chunk contains fan_size payload chunks
+        invocation_chunks = self.chunk_data(payload_chunks, self.fan_size)
+        
+        results = []
+        # async prediction on each invocation chunk
+        for invocation_chunk in invocation_chunks:
+            results += invoke_all(requests=invocation_chunk, region=self.region)
+            
+        # reconstruct outputs
+        predictions, scores, attentions = self.reconstruct_output(results)
+        attentions = self.reconstruct_attention(attentions)
+        return predictions, scores, attentions
+
+
+@st.cache(ignore_hash=True)
+def translate_data(smile_data, beam, n_best, attention, model_description):
+    function = model_description['function']
+    bucket = model_description['bucket']
+    lambda_interface = LambdaInterface(smile_data.smiles_tokens, beam, n_best, attention, 
+                                        function, bucket)
+
+    preds, scores, attns = lambda_interface.predict_async()
+    prediction = Predictions(smile_data, preds, scores, attns)
+    return prediction

--- a/Synthesis/translate_aws.py
+++ b/Synthesis/translate_aws.py
@@ -38,10 +38,10 @@ class LambdaInterface():
         self.s3 = boto3.client('s3')
         self.fan_size = config['fan_size']
         self.chunksize_dict = {
-                                1 : 60,
-                                2 : 50,
-                                3 : 40,
-                                5 : 30
+                                1 : 100,
+                                2 : 80,
+                                3 : 60,
+                                5 : 50
                               }
         self.region = 'us-west-2'
         
@@ -119,8 +119,8 @@ class LambdaInterface():
     def run_translation(self, data, beam, n_best, return_attention):
         # runs async prediction
 
-        payload_size = self.chunksize_dict[beam]
-        fan_size = min(self.fan_size, math.ceil(len(data)/payload_size))
+        fan_size = self.fan_size
+        payload_size = min(self.chunksize_dict[beam], math.ceil(len(data)/fan_size))
 
         # break data into chunks of size payload_size
         chunked_data = self.chunk_data(data, payload_size) #self.chunk_data(self.data, self.payload_size)

--- a/Synthesis/utils.py
+++ b/Synthesis/utils.py
@@ -92,8 +92,9 @@ def translate_data(smile_data, beam, n_best, attention, translator_class, model_
     translator = translator_class(model_description)
     scores, preds, attns = translator.run_translation(smile_data.smiles_tokens, 
                                                 beam=beam, n_best=n_best, return_attention=attention)
-    logger.info(f'Inference Time: {time.time() - start}')
+    prediction_time = time.time() - start
     prediction = Predictions(smile_data, preds, scores, attns)
+    logger.info(f'Inference Time: {prediction_time}')
     return prediction
 
 @st.cache

--- a/Synthesis/utils.py
+++ b/Synthesis/utils.py
@@ -81,12 +81,12 @@ def display_data(smile_data):
     else:
         st.image(smile_data.display(img_size=(300,300)))
 
-@st.cache(ignore_hash=True)
-def translate_data(smile_data, beam, n_best, model_description):
-    Translation = TranslationModel(model_description)
-    scores, preds, attns = Translation.run_translation(smile_data.smiles_tokens, beam=beam, n_best=n_best)
-    prediction = Predictions(smile_data, preds, scores, attns)
-    return prediction
+# @st.cache(ignore_hash=True)
+# def translate_data(smile_data, beam, n_best, model_description):
+#     Translation = TranslationModel(model_description)
+#     scores, preds, attns = Translation.run_translation(smile_data.smiles_tokens, beam=beam, n_best=n_best)
+#     prediction = Predictions(smile_data, preds, scores, attns)
+#     return prediction
 
 @st.cache
 def plot_topk(prediction_tokens, legend, img_size=(400,400)):

--- a/Synthesis/utils.py
+++ b/Synthesis/utils.py
@@ -75,14 +75,17 @@ def load_data(single_predict, source_param, target_param):
     # Returns a SilesData object
     return data 
 
-def display_data(smile_data):
+def display_data(smile_data, display_idx):
     # displays data held in a SmilesData object
-    if len(smile_data) > 1:
-        # If more than one SMILES is present, a streamlit slider bar is created
-        display_idx = st.slider('Display Index', 0, len(smile_data)-1, 0)
-        st.image(smile_data.display(idx=display_idx, img_size=(300,300)))
+    return st.image(smile_data.display(idx=display_idx, img_size=(300,300)))
+
+def display_slider(data):
+    if len(data) > 1:
+        display_idx = st.sidebar.slider('Display Index', 0, len(data)-1, 0)
     else:
-        st.image(smile_data.display(img_size=(300,300)))
+        display_idx = 0
+    
+    return display_idx
 
 @st.cache(ignore_hash=True)
 def translate_data(smile_data, beam, n_best, attention, translator_class, model_description):
@@ -102,14 +105,8 @@ def plot_topk(prediction_tokens, legend, img_size=(400,400)):
     mols = [Chem.MolFromSmiles(process_prediction(i)) for i in prediction_tokens]
     return Draw.MolsToGridImage(mols, legends=legend, subImgSize=img_size)
 
-def display_prediction(prediction):
-    #if prediction:
-    if len(prediction) > 1:
-        prediction_idx = st.slider('Prediction Index', 0, len(prediction)-1, 0)
-    else:
-        prediction_idx = 0
-
-    prediction_data = display_parameters(prediction, idx=prediction_idx)
+def display_prediction(prediction, display_idx):
+    prediction_data = display_parameters(prediction, idx=display_idx)
 
     st.write(f'Top {prediction.top_k} Predictions')
     st.image(plot_topk([i.prediction_tokens for i in prediction_data],

--- a/build/local.Dockerfile
+++ b/build/local.Dockerfile
@@ -1,0 +1,26 @@
+FROM continuumio/miniconda3
+
+RUN conda create -n deep_synthesis python=3.6
+ENV PATH /opt/conda/envs/deep_synthesis/bin:$PATH
+RUN /bin/bash -c "source activate deep_synthesis"
+RUN conda install -n deep_synthesis rdkit -c rdkit
+
+RUN git clone -b lambda_setup https://github.com/kheyer/Deep-Synthesis 
+
+RUN mkdir -p /root/.streamlit
+
+RUN bash -c 'echo -e "\
+[general]\n\
+email = \"\"\n\
+" > /root/.streamlit/credentials.toml'
+
+WORKDIR /Deep-Synthesis 
+RUN pip --no-cache-dir install -r requirements.txt
+
+RUN git clone https://github.com/kheyer/OpenNMT-py 
+
+RUN python build/download_model.py
+
+EXPOSE 8501
+
+CMD streamlit run Synthesis/app.py local

--- a/configs/aws_description.json
+++ b/configs/aws_description.json
@@ -1,0 +1,4 @@
+{
+    "function" : "TranslationFunction",
+    "bucket" : "deepsynthesis"
+}

--- a/configs/aws_description.json
+++ b/configs/aws_description.json
@@ -1,4 +1,5 @@
 {
     "function" : "TranslationFunction",
-    "bucket" : "deepsynthesis"
+    "bucket" : "deepsynthesis",
+    "fan_size" : 4
 }

--- a/configs/aws_description.json
+++ b/configs/aws_description.json
@@ -1,5 +1,5 @@
 {
     "function" : "TranslationFunction",
     "bucket" : "deepsynthesis",
-    "fan_size" : 4
+    "fan_size" : 2
 }

--- a/lambda_setup/README.md
+++ b/lambda_setup/README.md
@@ -1,0 +1,110 @@
+# Lambda Layer Setup
+
+For deploying the model on AWS, we want to run the model in an [AWS Lambda Function](https://aws.amazon.com/lambda/). The advantage of using AWS Lambda is we only pay for the compute time we use, rather than paying for an instance that is charged 24/7 regardless of use.
+
+The disadvantage to using Lambda is the tight constraints on the code you can deploy. A Lambda deployment is limited to 250 MB uncompressed. This is fine for our model, which is ~145 MB. The problem is loading all the python dependencies. Pytorch alone is over 1 GB. To actually get the model running on AWS Lambda, we need to do some sneaky stuff.
+
+Specifically, we need to create a leaned out version of our dependencies, package them into a zip file, then pull in the zip file to our lambda function as a layer. This lets us pull our dependences into the `/tmp` directory of the lambda function, which has a size limit of 500 MB. To get our package of dependencies below this limit, we will remove unnecessary packages (installing torch automatically installs caffe2 and other things we don't need), as well as unnecessary files like tests.
+
+Getting this all to work was quite difficult. Most of the code in this directory and the commands listed below are adapted from an excellent tutorial repo by [Matt McClean](https://github.com/mattmcclean/sam-pytorch-example) on creating Pytorch packages for AWS Lambda.
+
+## Overview
+
+To create our Lambda function, we need to do a few things:
+
+   1. Create a zip file of our dependencies (with excess files removes)
+   2. Create an AWS Lambda layer from that zip file
+   3. Package and deploy our inference Lambda function with the dependency lambda layer attached
+
+If you wish to follow these instructions to create the lambda layer and lambda function, it is assumed that you already have a functioning AWS account, as well as the AWS CLI and AWS SAM CLI installed and configured.
+
+## Creating The Zip File
+
+The lean dependency zip file is created with the `create_layer_file.sh` shell script in the `/layer` directory. This shell script first installs all the packages listed in the `requirements.txt` file in the `/translation_function` directory, then removes excess files. The full folder of lean dependencies comes out to about 480 MB in size. This is then zipped into a file called `OpenNMT-Pytorch-1.1.0-lambda-layer.zip`. To do this, run the following commands:
+
+    cd lambda_setup/layer
+    chmod +x create_layer_file.sh
+    ./create_layer_file.sh
+
+Once the zip file is created, we copy it to an S3 bucket
+
+    aws s3 cp OpenNMT-Pytorch-1.1.0-lambda-layer.zip s3://{BUCKET}/lambda-layers/OpenNMT-Pytorch-1.1.0-lambda-layer.zip
+
+## Creating the Lambda Layer
+
+Once the zip file is on S3, we can (in theory) create our Lambda layer from the command line
+
+    aws lambda publish-layer-version \
+        --layer-name “opennmt-py” \
+        --description "Lambda layer of OpenNMT Pytorch 1.1.0 zipped to be extracted with unzip_requirements file" \
+        --content "S3Bucket={BUCKET},S3Key=lambda-layers/OpenNMT-Pytorch-1.1.0-lambda-layer.zip" \
+        --compatible-runtimes "python3.6" 
+
+I say in theory because I often had issues getting this command to run. If the command throws an error or hangs, go to the `Layers` tab on the AWS Lambda console and click `Create Layer`. Follow the instructions to create a layer through the AWS console.
+
+Take note of the version ARN for the created lambda layer. ie `arn:aws:lambda:{REGION}:{ID}:layer:opennmt-py:1`. If you adapt this code to create a dependency layer of your own, update the `LambdaLayerArn` default value in the `template.yaml` file.
+
+The Lambda layer is now functional.
+
+## Deploying the Lambda Function
+
+The actual directory that will become the Lambda function is the `/translation_function` directory. This directory must be a flat directory containing all the files the Lambda function will need. The actual function called when the Lambda function is invoked is the `lambda_handler` function in the `app.py` file. This is specified in the `Handler` value of the `TranslationFunction` section in `template.yaml`.
+
+The trained model must also be stored in the `/translation_function` directory. This model is not stored on github for size reasons. It can be downloaded by running `download_model.py` from the `/lambda_setup` directory.
+
+    cd lambda_setup
+    python download_model.py
+
+Now we can create the Lambda function. First we package our files and upload them to S3
+
+    sam package \
+        --output-template-file packaged.yaml \
+        --s3-bucket {BUCKET}
+
+Then we deploy to AWS CloudFormation
+
+    sam deploy \
+        --template-file packaged.yaml \
+        --stack-name {APP_NAME} \
+        --capabilities CAPABILITY_IAM \
+        --parameter-overrides BucketName={BUCKET}
+
+Once creation is complete, the function is live and operational. There's just one more thing to do.
+
+When testing inference on AWS Lambda, I had issues with the message length limit on the response from the Lambda function. Trying to predict on a reasonable number of items and return all predictions, prediction scores and attention maps went way over the limit. To get around this, the function is designed to store all prediction outputs to S3 and return the S3 item key. To do this, the Lambda function must be given PUT permission for the S3 bucket in question.
+
+To do this, go to the AWS IAM console. Go to `Policies`, `Create Policy`, and add the following as a JSON input.
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+    {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListAllMyBuckets",
+                    "s3:GetBucketLocation"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": "s3:*",
+                "Resource": [
+                    "arn:aws:s3:::{BUCKET}",
+                    "arn:aws:s3:::{BUCKET}/*"
+                ]
+            }
+        ]
+    }
+
+Then go to `Roles` and find the role associated with `{APP_NAME}`. Attach the new policy to the role.
+
+Now everything is ready to go.
+
+## Testing Locally
+
+Once the function is set up and has proper S3 permissions, we can test the function locally. From the `/lambda_setup` directory, run the following.
+
+    sam local invoke TranslationFunction -n env.json -e event.json
+
+If everything is set up properly, this will run inference on the sample data in `event.json`, print prediction data to the console, store prediction data on S3 and return a JSON response containing the S3 object key for the stored predictions.

--- a/lambda_setup/download_model.py
+++ b/lambda_setup/download_model.py
@@ -1,0 +1,23 @@
+# Downloads model file to translation_function directory
+# Model file must be in directory before creating the Lambda function
+
+import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
+from pathlib import Path
+
+s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
+
+bucket_name = 'deepsynthesis'
+model_file = 'public_models/Molecular_transformer_step_400000.pt'
+destination_file = 'translation_function/Molecular_transformer_step_400000.pt'
+
+path = Path('.')
+file_path = path/destination_file 
+
+if not file_path.exists():
+    print('Downloading Model File')
+    (path/'models').mkdir(exist_ok=True)
+    s3.download_file(bucket_name, model_file, destination_file)
+else:
+    print('Model already downloaded')

--- a/lambda_setup/env.json
+++ b/lambda_setup/env.json
@@ -1,0 +1,5 @@
+{
+    "TranslationFunction": {
+      "MODEL_BUCKET": "deepsynthesis"
+    }
+}

--- a/lambda_setup/event.json
+++ b/lambda_setup/event.json
@@ -2,5 +2,6 @@
     "data" : "[\"C C ( C ) = O . C O c 1 c c c ( S ( = O ) ( = O ) C l ) c c 1 . [ I - ] . [ N a + ]\", \"C C ( C ) ( C ) [ O - ] . N # C c 1 c ( N ) n c ( C l ) c ( C # N ) c 1 - c 1 c c c c c 1 . O C c 1 c c c c n 1 . [ K + ]\", \"C 1 C C O C 1 . C C C C C C C . C N 1 C C C ( C C O ) C C 1 . C c 1 c c c ( N 2 C C N ( C ( = O ) O c 3 c c c ( [ N + ] ( = O ) [ O - ] ) c c 3 ) C C 2 ) c c 1 . [ H - ] . [ N a + ]\"]",
     "beam" : 5,
     "n_best" : 5,
-    "return_attention" : true
+    "return_attention" : true,
+    "warmup" : false
 }

--- a/lambda_setup/event.json
+++ b/lambda_setup/event.json
@@ -1,0 +1,6 @@
+{
+    "data" : "[\"C C ( C ) = O . C O c 1 c c c ( S ( = O ) ( = O ) C l ) c c 1 . [ I - ] . [ N a + ]\", \"C C ( C ) ( C ) [ O - ] . N # C c 1 c ( N ) n c ( C l ) c ( C # N ) c 1 - c 1 c c c c c 1 . O C c 1 c c c c n 1 . [ K + ]\", \"C 1 C C O C 1 . C C C C C C C . C N 1 C C C ( C C O ) C C 1 . C c 1 c c c ( N 2 C C N ( C ( = O ) O c 3 c c c ( [ N + ] ( = O ) [ O - ] ) c c 3 ) C C 2 ) c c 1 . [ H - ] . [ N a + ]\"]",
+    "beam" : 5,
+    "n_best" : 5,
+    "return_attention" : true
+}

--- a/lambda_setup/layer/create_layer_file.sh
+++ b/lambda_setup/layer/create_layer_file.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# this script downloads all the packages in requirements.txt, 
+# removes unnecessary files, and packages them into a zip file
+# that can be used to create a labmda layer
+
+# This code is adapted from a repo by Matt McClean
+# https://github.com/mattmcclean/sam-pytorch-example
+set -e
+
+PYTORCH_VERSION=${1:-"1.1.0"}
+LAYER_ZIP_NAME="OpenNMT-Pytorch-${PYTORCH_VERSION}-lambda-layer.zip"
+
+if [[ -f "${LAYER_ZIP_NAME}" ]]; then
+    echo "Deleting zipfiles"
+    rm *.zip
+fi
+
+echo "Installing packages"
+cd ..
+sam build -u
+
+echo "Bundling PyTorch packages into zip file"
+mkdir -p .aws-sam/build/layers
+cp -R .aws-sam/build/TranslationFunction/* .aws-sam/build/layers/
+cd .aws-sam/build/layers/ 
+du -sch . 
+find . -type d -name "tests" -exec rm -rf {} +
+find . -type d -name "__pycache__" -exec rm -rf {} +
+rm -rf ./{caffe2,wheel,pkg_resources,boto*,aws*,pip,pipenv,setuptools} 
+rm ./torch/lib/libtorch.so 
+rm -rf ./{*.egg-info,*.dist-info} 
+find . -name \*.pyc -delete
+rm {app.py,requirements.txt,model_config.json,translate.py} 
+du -sch . 
+cd - 
+# build the .requirements.zip file
+cd .aws-sam/build/layers/
+zip -9 -q -r ../../../layer/.requirements.zip . 
+cd -
+
+echo "Creating layer zipfile"
+cd layer
+zip -9 ${LAYER_ZIP_NAME} .requirements.zip -r python/
+
+echo "Delete the requirements zipfile & build directory"
+rm .requirements.zip
+rm -rf ../.aws-sam/build

--- a/lambda_setup/layer/create_layer_file.sh
+++ b/lambda_setup/layer/create_layer_file.sh
@@ -28,6 +28,7 @@ find . -type d -name "tests" -exec rm -rf {} +
 find . -type d -name "__pycache__" -exec rm -rf {} +
 rm -rf ./{caffe2,wheel,pkg_resources,boto*,aws*,pip,pipenv,setuptools} 
 rm ./torch/lib/libtorch.so 
+rm -rf ./torch/test
 rm -rf ./{*.egg-info,*.dist-info} 
 find . -name \*.pyc -delete
 rm {app.py,requirements.txt,model_config.json,translate.py} 

--- a/lambda_setup/layer/python/unzip_requirements.py
+++ b/lambda_setup/layer/python/unzip_requirements.py
@@ -1,0 +1,25 @@
+# This script unzips the lambda layer containing dependencies
+# This code is adapted from a repo by Matt McClean
+# https://github.com/mattmcclean/sam-pytorch-example
+
+import os
+import shutil
+import sys
+import zipfile
+
+
+pkgdir = '/tmp/sls-py-req'
+
+sys.path.append(pkgdir)
+
+if not os.path.exists(pkgdir):
+    tempdir = '/tmp/_temp-sls-py-req'
+    if os.path.exists(tempdir):
+        shutil.rmtree(tempdir)
+
+    default_layer_root = '/opt'
+    lambda_root = os.getcwd() if os.environ.get('IS_LOCAL') == 'true' else default_layer_root
+    zip_requirements = os.path.join(lambda_root, '.requirements.zip')
+
+    zipfile.ZipFile(zip_requirements, 'r').extractall(tempdir)
+    os.rename(tempdir, pkgdir)  # Atomic

--- a/lambda_setup/template.yaml
+++ b/lambda_setup/template.yaml
@@ -1,0 +1,66 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Creates the Lambda function and API for the Translation inference application.
+
+Parameters: 
+  BucketName: 
+    Type: String
+    Default: somebucket
+    Description: Enter the name of the S3 bucket storing your Translation model artefacts.
+  ObjectKey: 
+    Type: String
+    Default: somekey
+    Description: Enter the S3 object key path of your Translation model artefacts.
+  LambdaLayerArn:
+    Type: String
+    Default: "arn:aws:lambda:us-west-2:791915736361:layer:opennmt-py:1"
+    Description: Lambda layer ARN with Pytorch/OpenNMT dependencies
+
+# More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
+
+Globals:
+    Function:
+        Timeout: 120
+
+Resources:
+
+  TranslationFunction:
+      Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+      Properties:
+          CodeUri: translation_function/
+          Handler: app.lambda_handler
+          FunctionName : TranslationFunction
+          Runtime: python3.6
+          MemorySize: 2048
+          Environment:
+            Variables:
+              MODEL_BUCKET: !Ref BucketName
+              MODEL_KEY: !Ref ObjectKey
+          Policies:
+            - S3ReadPolicy:
+                BucketName: !Ref BucketName
+          Layers:
+            - !Ref LambdaLayerArn 
+          Events:
+              Translation:
+                  Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+                  Properties:
+                      Path: /invocations
+                      Method: post
+                        
+Outputs:
+
+    # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+    # Find out more about other implicit resources you can reference within SAM
+    # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+    TranslationApi:
+      Description: "API Gateway endpoint URL for Prod stage for Translation function"
+      Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/invocations/"
+
+    TranslationFunction:
+      Description: "Translation Lambda Function ARN"
+      Value: !GetAtt TranslationFunction.Arn
+
+    TranslationFunctionIamRole:
+      Description: "Implicit IAM Role created for Translation function"
+      Value: !GetAtt TranslationFunctionRole.Arn                        

--- a/lambda_setup/template.yaml
+++ b/lambda_setup/template.yaml
@@ -13,7 +13,7 @@ Parameters:
     Description: Enter the S3 object key path of your Translation model artefacts.
   LambdaLayerArn:
     Type: String
-    Default: "arn:aws:lambda:us-west-2:791915736361:layer:opennmt-py:1"
+    Default: "arn:aws:lambda:us-west-2:791915736361:layer:opennmt-py:2"
     Description: Lambda layer ARN with Pytorch/OpenNMT dependencies
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
@@ -31,7 +31,7 @@ Resources:
           Handler: app.lambda_handler
           FunctionName : TranslationFunction
           Runtime: python3.6
-          MemorySize: 2048
+          MemorySize: 3008
           Environment:
             Variables:
               MODEL_BUCKET: !Ref BucketName

--- a/lambda_setup/translation_function/app.py
+++ b/lambda_setup/translation_function/app.py
@@ -75,7 +75,7 @@ def lambda_handler(event, context):
     if event['warmup']:
         response = {'warmup' : 'confirmed'}
     else:
-        response = run_translation(event)
+        response = run_translation(event, context)
 
     print("Returning response")
     return {
@@ -83,13 +83,12 @@ def lambda_handler(event, context):
         "body": response
     }
 
-def run_translation(event):
+def run_translation(event, context):
     # processes event info, runs translation and saves output to S3
     beam = event['beam']
     n_best = event['n_best']
     return_attention = event['return_attention']
     data = json.loads(event['data'])
-    event_id = context.aws_request_id
 
     print("Starting Prediction")
     predictions = predict(data, beam, n_best, return_attention)

--- a/lambda_setup/translation_function/app.py
+++ b/lambda_setup/translation_function/app.py
@@ -1,0 +1,132 @@
+'''
+app.py
+
+This script serves as the handler function for AWS Lambda
+
+The code here is based off a repo written by Matt McClean 
+https://github.com/mattmcclean/sam-pytorch-example
+
+The lambda_handler function takes in an event as input,
+runs predictions on the content of the event, and stores the 
+outputs to an S3 bucket. The S3 key for the saved predictions
+is returned in a JSON response.
+
+The input event should be structured as follows:
+
+{
+    "beam" : int,
+    "n_best" : int
+    "return_attention" : bool
+    "data" : Tokenized SMILES data dumped to a JSON string
+}
+
+This function is designed to import dependencies from a Lambda layer.
+Loading in the layer is done with the unzip_requirements function
+'''
+  
+# this import statement is needed if you want to use an AWS Lambda Layer to load dependencies
+# it unzips all of the pytorch & dependency packages when the script is loaded to 
+# avoid the 250 MB unpacked limit in AWS Lambda
+
+try:
+    import unzip_requirements
+except ImportError:
+    pass
+
+import logging
+import time
+import boto3 
+import requests
+import json
+import numpy as np
+import pickle
+import pdb
+import gzip
+
+import os
+
+from translate import *
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# connect to S3 
+# Lambda function must be given S3 get/put permissions
+s3 = boto3.client('s3')
+
+# get bucket name from ENV variable
+MODEL_BUCKET=os.environ.get('MODEL_BUCKET')
+logger.info(f'Model Bucket is {MODEL_BUCKET}')
+
+# Load model config, load model from config
+model_description = json.load(open('model_config.json'))
+logger.info('Loading model')
+Translator = TranslationModel(model_description)
+
+# Handles incoming events to lambda function
+def lambda_handler(event, context):
+
+    print("Starting event")
+    logger.info(event)
+
+    # extract info from event/context
+    beam = event['beam']
+    n_best = event['n_best']
+    return_attention = event['return_attention']
+    data = json.loads(event['data'])
+    event_id = context.aws_request_id
+
+    print("Starting Prediction")
+    # run prediction
+    predictions = predict(data, beam, n_best, return_attention)
+
+    # compress outputs to gzip format and store on S3
+    # this will throw an error if permissions are not added
+    gzip_filename = 'prediction_outputs/' + context.aws_request_id + '.gz'
+    gzip_object = gzip.compress(pickle.dumps(predictions))
+    s3.put_object(Body=gzip_object, Bucket=MODEL_BUCKET, Key=gzip_filename)
+
+    # send S3 key in response
+    response = {'s3_key' : gzip_filename}
+    print("Returning response")
+    return {
+        "statusCode": 200,
+        "body": response
+    }
+
+def predict(data, beam, n_best, return_attention):
+    # function runs predictions and processes outputs
+    logger.info("Starting Prediction")
+    logger.info(f"Prediction Scope: {len(data)} examples + {beam} beam width")
+    start_time = time.time()
+    scores, preds, attns = Translator.run_translation(data, 
+                                        beam=beam, n_best=n_best, return_attention=return_attention)
+    logger.info("--- Inference time: %s seconds ---" % (time.time() - start_time))
+    response = {}
+    response['predictions'] = preds 
+    response['scores'] = process_scores(scores)
+    response['attention'] = process_attention(attns)
+
+    return response
+
+def process_scores(scores):
+    # scores are torch tensors, must be cast to float
+    new_scores = []
+
+    for score_set in scores:
+        float_scores = [i.item() for i in score_set]
+        new_scores += [float_scores]
+    
+    return new_scores
+
+def process_attention(attns):
+    # attention maps are numpy arrays.
+    # arrays are converted to lists prior to compression
+    new_attentions = []
+    
+    for attention_set in attns:
+        list_attentions = [np.around(i, decimals=4).tolist() for i in attention_set]
+        new_attentions += [list_attentions]
+        
+    return new_attentions

--- a/lambda_setup/translation_function/model_config.json
+++ b/lambda_setup/translation_function/model_config.json
@@ -1,0 +1,13 @@
+{
+    "id": 100,
+    "model": "Molecular_transformer_step_400000.pt",
+    "opt": {
+        "beam_size": 10,
+        "n_best" : 10,
+        "batch_size" : 64,
+        "min_length" : 3,
+        "max_length" : 200,
+        "replace_unk" : true,
+        "verbose" : true
+    }
+}

--- a/lambda_setup/translation_function/requirements.txt
+++ b/lambda_setup/translation_function/requirements.txt
@@ -1,0 +1,8 @@
+numpy==1.11.3
+https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
+requests
+six
+git+https://github.com/pytorch/text.git@master#wheel=torchtext
+git+https://github.com/kheyer/OpenNMT-py
+future
+configargparse

--- a/lambda_setup/translation_function/translate.py
+++ b/lambda_setup/translation_function/translate.py
@@ -1,0 +1,136 @@
+from onmt.utils.parse import ArgumentParser
+import onmt.opts as opts
+from onmt.translate.translator import build_translator
+import torch
+
+import types
+import io
+
+
+class TranslationModel:
+    '''
+    Class for handing machine translation
+    The TranslationModel class will load a model given a config file
+
+    The config file should contain:
+    Path to the model (string)
+    Beam size (int)
+    K best predictions (int)
+    Minimum prediction length (int)
+    Maximum prediction length (int)
+    Replace unk (bool)
+
+    This class is designed to work with models created with OpenNMT
+    OpenNMT relies on an extensive argparse structure to create models
+    The code here has been build to plug into that framework
+    '''
+    def __init__(self, config):
+        self.config = config
+
+        # Configure GPU if available
+        if torch.cuda.is_available():
+            self.config['opt']['gpu'] = 0
+            self.gpu = True 
+        else:
+            self.gpu = False
+
+        # create OpenNMT opt object
+        self.opt = self.configure_opt(config)
+
+        # use opt to load model
+        self.translator = self.load_translator(self.opt)
+        self.base_beam = self.translator.beam_size
+        self.base_best = self.translator.n_best
+
+    def configure_opt(self, description):
+        # Uses OpenNMT's ArgumentParser class to create an object
+        # That holds all the parameters needed to load the model
+        parser = ArgumentParser(description='translation')
+        opts.config_opts(parser)
+        opts.translate_opts(parser)
+        opt = {a.dest: a.default for a in parser._actions}
+        opt.update(description['opt'])
+        opt['models'] = [description['model']]
+        opt = types.SimpleNamespace(**opt)
+
+        return opt
+
+    def load_translator(self, opt):
+        # Loads a model based on the parameters in opt
+
+        # OpenNMT requires some sort of output file to write to
+        # Since we don't intent to write predictions to a file, we 
+        # can use a StringIO object
+        output = io.StringIO()
+
+        # build_translator is an OpenNMT function
+        translator = build_translator(opt, out_file=output)
+
+        return translator
+
+    def run_translation(self, src, beam=None, n_best=None, return_attention=True):
+        # Runs src through a loaded model and generates predictions
+        # src should be a list of processed and tokenized SMILES
+
+        self.translator.out_file.seek(0)
+        self.translator.out_file.truncate(0)
+        
+        # beam and n_best are set in opt, but we can overwrite those values if desired
+        if beam:
+            self.translator.beam_size = beam
+        if n_best:
+            self.translator.n_best = n_best
+            
+        # beam size must be greater than or equal to the number of final predictions
+        assert self.translator.beam_size >= self.translator.n_best
+        
+        # sets batch size based on beam size and hardware (GPU or CPU)
+        bs = self.get_batch_size(self.translator.beam_size)
+
+        # outputs from translation
+        # all outputs are lists of lists
+        scores, preds, attns = self.translator.translate(src, batch_size=bs, return_attention=True)
+        
+        if beam or n_best:
+            self.reset_params()
+
+        if return_attention:
+            return (scores, preds, attns)
+        else:
+            return (scores, preds)
+
+    def reset_params(self):
+        # reset beam_size and n_best parameters if desired
+        self.translator.beam_size = self.base_beam
+        self.translator.n_best = self.base_best
+
+    def get_batch_size(self, beam):
+        # Calls correct batch size function based on CPU or GPU inference
+        if self.gpu:
+            bs =  self.get_batch_size_gpu(beam)
+        else:
+            bs = self.get_batch_size_cpu(beam)
+
+        return bs
+
+    def get_batch_size_cpu(self, beam):
+        # Optinum batch sizes for CPU inference
+        # based on AWS Lambda 2048 MB instance
+        if beam >= 10:
+            return 10
+        else:
+            return 15
+    
+    def get_batch_size_gpu(self, beam):
+        # Optimum batch sizes for GPU inference 
+        # Based off K80 GPU
+        if beam == 1:
+            bs = 256
+        if beam >=2:
+            bs = 192
+        if beam >= 5:
+            bs = 128
+        if beam >= 10:
+            bs = 64
+            
+        return bs

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ streamlit
 pandas
 numpy
 seaborn
-matplotlib
+matplotlib==3.0.0
 aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pandas
 numpy
 seaborn
 matplotlib
+aiohttp


### PR DESCRIPTION
Hey Zig,

This is a pull request to bring in all the code based around setting up an AWS Lambda function for inference and calling that function from the Streamlit app.

Major Changes:

`/lambda_setup` directory - this directory contains all the code required to set up inference on AWS Lambda. This includes code to create a Lambda layer for the dependencies. Instructions for actually doing this are in the readme of the directory.

`translate_aws.py` and `lambda_async.py` - these two python files contain functions to connect to AWS Lambda to run inference. `translate_aws.py` contains a class designed to handle preprocessing data for sending to AWS Lambda and processing inference outputs into the same form you would get running local prediction. `lambda_async.py` has some functions that allow for invoking Lambda functions concurrently for some extra prediction speed.

Requests for feedback:

On handling both local predictions and AWS predictions:

When I was rewriting things to work with predicting on AWS Lambda, I wanted to do things in such a way that local prediction was still possible for anyone interested in setting this up at home. I built things in such a way that different translation files (`translate.py` vs `translate_aws.py` can be swapped out easily. An interesting thing that came out of this is that prediction with AWS does not require OpenNMT to be cloned into the directory running the app, as all the translation dependencies are packaged with the AWS Lambda function. Taking advantage of this, I added an argparse system to `app.py`, where running `streamlit run Synthesis/app.py local` imports OpenNMT for translation, while running `streamlit run Synthesis/app.py AWS` does not. This works, but it feels clunky to have conditional imports based on a command line argument. Is there a better way to do this?

On downloading model files for local deployment vs AWS Lambda setup:

For running inference locally, the setup script `buildEnv.sh` runs `python build/download_model.py` to create a `/models` directory and download the trained model to that location. For setting up AWS Lambda, I added an almost identical copy of `download_model.py` designed to download the model to the relevant folder for creating a Lambda function. I thought about using a single function that would take a command line argument for the destination folder. Ultimately I decided against this because I preferred to have all scripts required to set up AWS Lambda contained in a single directory. What are your thoughts on this?

On code attribution:

Setting up a Pytorch model on AWS Lambda is surprisingly hard, and I had to use a lot of code written by others for the same task. I wanted to make sure I was properly attributing code. The code in `lambda_async.py` was taken from [this gist](https://gist.github.com/byrro/439d233636ac6894f87c1df6ff1fa298), and I added the attribution requested by the author to the python file. Several files in the `/lambda_setup` directory are taken from [this repo](https://github.com/mattmcclean/sam-pytorch-example). I include the repo link in the relevant files and link to it in the README in the `/lambda_setup` directory. Is this sufficient for attribution?